### PR TITLE
Fix for network/network-uri split

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,13 @@
 dist
 *~
 #*#
+cabal-dev
+*.o
+*.hi
+*.chi
+*.chs.h
+.virtualenv
+.hsenv
+.cabal-sandbox/
+cabal.sandbox.config
+cabal.config

--- a/httpd-shed.cabal
+++ b/httpd-shed.cabal
@@ -1,5 +1,5 @@
 Name:           httpd-shed
-Version:        0.4.0.1
+Version:        0.4.0.3
 Cabal-Version:  >= 1.2
 License:        BSD3
 License-File:   LICENSE
@@ -29,18 +29,25 @@ Flag buildExamples
   Description: Build example executables
   Default:     False
 
-Library
-  Build-Depends:
-    network >=2.3 && <2.6,
-    base >=4.0 && <5.0
-  Ghc-Options: -Wall
-  Exposed-modules:
-    Network.Shed.Httpd
+flag network-uri
+  description: Get Network.URI from the network-uri package
+  default:     True
 
+Library
+  Build-Depends:        base >= 4.0 && < 5.0
+  
+  if flag(network-uri)
+    Build-Depends:      network     >= 2.6 && < 2.7,
+                        network-uri >= 2.6 && < 2.7
+  else
+    Build-Depends:      network     >= 2.3 && < 2.6
+  
+  Ghc-Options:          -Wall
+  Exposed-modules:      Network.Shed.Httpd
 
 -- Trivial test; we need real tests!
 Executable httpd-shed-test
   If !flag(buildExamples)
-    Buildable: False
-  Main-Is:        Main.hs
-  Hs-Source-Dirs: ., test
+    Buildable:          False
+  Main-Is:              Main.hs
+  Hs-Source-Dirs:       ., test


### PR DESCRIPTION
Since the URI functionality of `network` was split off into the [`network-uri`](http://hackage.haskell.org/package/network-uri) package (as of version 2.6.0.0), `httpd-shed` should start using `network-uri` (and allow a way to use earlier versions of `network` via a flag).
